### PR TITLE
set the resource requirements as per usage

### DIFF
--- a/manifests/base/deploymentconfig.yaml
+++ b/manifests/base/deploymentconfig.yaml
@@ -27,10 +27,10 @@ spec:
           resources:
             requests:
               memory: "384Mi"
-              cpu: "2"
+              cpu: "100m"
             limits:
               memory: "768Mi"
-              cpu: "2"
+              cpu: "100m"
           readinessProbe:
             httpGet:
               path: "/metrics"


### PR DESCRIPTION
## Related Issues and Dependencies

Related-to: https://github.com/AICoE/elyra-aidevsecops-tutorial/issues/161

## Description

- deployment is using only 1m , to be cautious we have reduced the requested cpu to 100m.

set the resource requirements as per usage
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
