### PR TITLE
Use new elyra custom image for build

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -22,7 +22,7 @@ overlays:
 
   - name: experiment
     build:
-      base-image: "quay.io/thoth-station/s2i-elyra-custom-notebook:latest"
+      base-image: "quay.io/thoth-station/s2i-elyra-custom-notebook:v0.3.1"
       build-source-script: "image:///opt/app-root/builder"
       custom-tag: latest
       build-stratergy: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Use new elyra custom image for build (it has new jupyterlab-requirements v0.8.0)